### PR TITLE
enable prettier by default

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "requirePragma": true,
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": false,

--- a/example/App.js
+++ b/example/App.js
@@ -2,7 +2,6 @@
  * Sample React Native App
  * https://github.com/facebook/react-native
  *
- * @format
  * @flow
  */
 

--- a/example/ProgressBarAndroidExample.android.js
+++ b/example/ProgressBarAndroidExample.android.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow
  */
 

--- a/example/ProgressBarTestModule.js
+++ b/example/ProgressBarTestModule.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  */
 
 'use strict';

--- a/example/RNTesterBlock.js
+++ b/example/RNTesterBlock.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow
  */
 

--- a/example/RNTesterPage.js
+++ b/example/RNTesterPage.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow
  */
 

--- a/example/RNTesterTitle.js
+++ b/example/RNTesterTitle.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow strict-local
  */
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import {AppRegistry} from 'react-native';
 
-import {name as appName}  from './app.json';
+import {name as appName} from './app.json';
 import ProgressBarAndroidExample from './ProgressBarAndroidExample.android';
 
 class ExampleApp extends React.Component<{}> {
   render() {
-    return (
-        <ProgressBarAndroidExample />
-    );
+    return <ProgressBarAndroidExample />;
   }
 }
 AppRegistry.registerComponent(appName, () => ExampleApp);

--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -2,7 +2,6 @@
  * Metro configuration for React Native
  * https://github.com/facebook/react-native
  *
- * @format
  */
 
 module.exports = {

--- a/js/RNCProgressBarAndroid.android.js
+++ b/js/RNCProgressBarAndroid.android.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @format
  */
 
 'use strict';

--- a/js/RNCProgressBarAndroid.ios.js
+++ b/js/RNCProgressBarAndroid.ios.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  */
 
 'use strict';

--- a/js/RNCProgressBarAndroidNativeComponent.js
+++ b/js/RNCProgressBarAndroidNativeComponent.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @format
  */
 
 'use strict';

--- a/js/__tests__/RNCProgressBarAndroid.android.test.js
+++ b/js/__tests__/RNCProgressBarAndroid.android.test.js
@@ -10,7 +10,9 @@ describe('<ProgressBar />', () => {
   });
 
   it('renders Horizontal ProgressBar', () => {
-    const tree = renderer.create(<ProgressBar styleAttr="Horizontal" />).toJSON();
+    const tree = renderer
+      .create(<ProgressBar styleAttr="Horizontal" />)
+      .toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "start:android": "adb shell am start -n com.androidprogressbar/.MainActivity",
     "build:android": "cd example/android && ./gradlew clean assembleDebug",
     "test": "jest",
-    "lint": "eslint 'js/**/*.js' && eslint 'example/**/*.js'",
-    "type-check":"tsc --noEmit"
+    "lint": "eslint 'js/**/*.js' 'example/**/*.js'",
+    "type-check": "tsc --noEmit"
   },
   "homepage": "https://github.com/react-native-community/react-native-progress-bar-android#readme",
   "repository": {
@@ -46,16 +46,13 @@
   "devDependencies": {
     "@babel/core": "^7.4.3",
     "@babel/runtime": "^7.4.3",
-    "@react-native-community/eslint-config": "0.0.6",
-    "@react-native-community/eslint-plugin": "^1.0.0",
+    "@react-native-community/eslint-config": "^0.0.7",
     "@types/react": "^16.9.17",
     "babel-jest": "^25.1.0",
     "babel-plugin-module-resolver": "^3.2.0",
     "eslint": "5",
-    "eslint-plugin-prettier": "^3.0.1",
     "jest": "^25.1.0",
     "metro-react-native-babel-preset": "^0.58.0",
-    "prettier": "^1.17.0",
     "react": "16.9.0",
     "react-native": "^0.61.5",
     "react-test-renderer": "16.8.3",

--- a/react-native-progress-bar-android.podspec
+++ b/react-native-progress-bar-android.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.description  = package['description']
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/react-native-community/react-native-progress-bar-android.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/react-native-community/react-native-progress-bar-android.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/RNCAndroidprogressbar/**/*.{h,m}"
   s.requires_arc = true
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1345,11 +1345,12 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
-"@react-native-community/eslint-config@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@react-native-community/eslint-config/-/eslint-config-0.0.6.tgz#9f1dffde994a14db7504a969f21cdf49f470eb34"
-  integrity sha512-jtMZ1fzYYykrllbTCATZ8n5HS6Npwv9gusPk/+lMUBrmLXolGFiHFJQIpdcQzWFQb6POigAxo0O+xSiwlsT7Rw==
+"@react-native-community/eslint-config@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@react-native-community/eslint-config/-/eslint-config-0.0.7.tgz#2a91d336b413d8c77ac5fa634b66703f481243ac"
+  integrity sha512-khKxg3BMsXZYSXLat0ygSqTM0KdgciK+gm+hGecM7HzQA10hNTKeMmoFNiNxV+M/5PUyTsnRAz4RtWPVWLuPfQ==
   dependencies:
+    "@react-native-community/eslint-plugin" "^1.0.0"
     "@typescript-eslint/eslint-plugin" "^1.5.0"
     "@typescript-eslint/parser" "^1.5.0"
     babel-eslint "10.0.3"
@@ -2770,13 +2771,6 @@ eslint-plugin-prettier@2.6.2:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
-eslint-plugin-prettier@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
-  integrity sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
 eslint-plugin-react-hooks@^2.0.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.3.0.tgz#53e073961f1f5ccf8dd19558036c1fac8c29d99a"
@@ -3085,7 +3079,7 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-diff@^1.1.1, fast-diff@^1.1.2:
+fast-diff@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
@@ -5867,14 +5861,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
-
-prettier@1.17.0, prettier@^1.17.0:
+prettier@1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
   integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I removed `"requirePragma": true` from `prettierrc` because that option means prettier is not enabled unless explicitly turned on using the `@format` pragma (as it was in `example/index.js`).

After that I just ran `eslint --fix` and the code now follows the specified config.


<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

- eslint passes (it does locally :) )

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
