### PR TITLE
fix(android): android gradle plugin 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,6 +65,13 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    // Check AGP version for backward compatibility w/react-native versions still on gradle plugin 6
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace = "com.reactnativecommunity.androidprogressbar"
+    }
+
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
     defaultConfig {


### PR DESCRIPTION

Hi there 👋 

This is the minimal change to support android gradle plugin 8 coming up with react-native 0.73, while still maintaining backwards compatibility with much older react-native that still bundles android gradle plugin <= 6

It does not attempt to do anything with the AndroidManifest.xml file, as leaving the namespace in there is only a warning, but it allows the module to compile when I use it in my work app where I'm testing AGP8+ compatibility in the modules I maintain and use

Cheers