### PR TITLE
chore: Remove legacy version check in react-native.config.js

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,24 +1,3 @@
-let supportsCodegenConfig = false;
-
-try {
-  const rnCliAndroidVersion = require('@react-native-community/cli-platform-android/package.json')
-    .version;
-  const [major] = rnCliAndroidVersion.split('.');
-  supportsCodegenConfig = major >= 9;
-} catch (e) {
-  // ignore
-}
-
-// this is a quick workaround for enabling custom codegen config in the fabric example app
-// the require above picks up the version of the cli-platform-android package from the root node_modules
-// instead of the one from the example app and doesn't correctly set the flag
-// this, along with the patch to the rncli allows to run the fabric example properly
-const codegenSwitch = '--enable-rnandroidprogressbar-codegen';
-if (process.argv.includes(codegenSwitch)) {
-  process.argv = process.argv.filter((arg) => arg !== codegenSwitch);
-  supportsCodegenConfig = true;
-}
-
 module.exports = {
   project: {
     android: {sourceDir: './example/android'},
@@ -26,12 +5,10 @@ module.exports = {
   },
   dependency: {
     platforms: {
-      android: supportsCodegenConfig
-        ? {
-            componentDescriptors: ['RNCProgressBarComponentDescriptor'],
-            cmakeListsPath: '../android/src/main/jni/CMakeLists.txt',
-          }
-        : {},
+      android: {
+        componentDescriptors: ['RNCProgressBarComponentDescriptor'],
+        cmakeListsPath: '../android/src/main/jni/CMakeLists.txt',
+      },
     },
   },
 };


### PR DESCRIPTION
## Description

Removes legacy version check from `react-native.config.js`. 

## Changes

The community CLI is no longer a dependency for React Native, meaning it may not be installed in every project. For example, projects that use Expo won't include the `@react-native-community/cli-*` packages. Consequently, this check will fail, leading to issues with autolinking components.

This version check can be removed safely, as the 9th version of the CLI was released two years ago. 

## Tests

This change was tested using `expo` project on react native `0.76`.